### PR TITLE
Add "-ldl" for static linking

### DIFF
--- a/modules/math_libs.cmake
+++ b/modules/math_libs.cmake
@@ -506,7 +506,7 @@ if (ENABLE_STATIC_LINKING)
         BLAS_TYPE MATCHES SYSTEM_NATIVE OR
         BLAS_TYPE MATCHES OPENBLAS)
         #cc_blas_static with ATLAS on travis-ci needs -lm
-        set(MATH_LIBS ${MATH_LIBS} -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -lm)
+        set(MATH_LIBS ${MATH_LIBS} -Wl,--whole-archive -lpthread -ldl -Wl,--no-whole-archive -lm)
     endif()
     if (LAPACK_TYPE MATCHES MKL OR
         BLAS_TYPE MATCHES MKL)


### PR DESCRIPTION
Hi Rado,

to fix dirac.x static linking ( OpenMPI+GNU+OPENBLAS ) I had to inser -ldl after -lpthread command.

Please proprage it into DIRAC repo. Thanks.