### PR TITLE
Parse language field in YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,15 @@ matrix:
     - os: osx
       osx_image: xcode6.4
       compiler: gcc
-      env: SOURCES=homebrew
+      env:
+        - SOURCES=homebrew
+        - HOMEBREW_GCC='homebrew/versions/gcc48'
 
 install:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-        brew install cmake boost python gcc open-mpi
+        brew install cmake boost python open-mpi
+        brew reinstall ${HOMEBREW_GCC}
         pip install virtualenv
     elif [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
         pip install --user virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,17 +53,16 @@ matrix:
             - libboost-all-dev
 
     - os: osx
-      osx_image: xcode6.4
+      osx_image: xcode7.3
       compiler: gcc
       env:
         - SOURCES=homebrew
-        - HOMEBREW_GCC='homebrew/versions/gcc48'
 
 install:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
         brew install cmake boost python open-mpi
-        brew reinstall ${HOMEBREW_GCC}
+        brew reinstall gcc
         pip install virtualenv
     elif [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
         pip install --user virtualenv

--- a/autocmake/generate.py
+++ b/autocmake/generate.py
@@ -118,7 +118,7 @@ def gen_setup(config, default_build_type, relative_path, setup_script_name):
     return s
 
 
-def gen_cmakelists(project_name, min_cmake_version, default_build_type, relative_path, modules):
+def gen_cmakelists(project_name, project_language, min_cmake_version, default_build_type, relative_path, modules):
     """
     Generate CMakeLists.txt.
     """
@@ -132,7 +132,7 @@ def gen_cmakelists(project_name, min_cmake_version, default_build_type, relative
     s.append('cmake_minimum_required(VERSION {0} FATAL_ERROR)'.format(min_cmake_version))
 
     s.append('\n# project name')
-    s.append('project({0})'.format(project_name))
+    s.append('project({0} {1})'.format(project_name, project_language))
 
     s.append('\n# do not rebuild if rules (compiler flags) change')
     s.append('set(CMAKE_SKIP_RULE_DEPENDENCY TRUE)')

--- a/modules/cc.cmake
+++ b/modules/cc.cmake
@@ -25,8 +25,6 @@
 #   export: "'CC={0}'.format(arguments['--cc'])"
 #   define: "'-DEXTRA_CFLAGS=\"{0}\"'.format(arguments['--extra-cc-flags'])"
 
-enable_language(C)
-
 if(NOT DEFINED CMAKE_C_COMPILER_ID)
     message(FATAL_ERROR "CMAKE_C_COMPILER_ID variable is not defined!")
 endif()

--- a/modules/cxx.cmake
+++ b/modules/cxx.cmake
@@ -25,14 +25,12 @@
 #   export: "'CXX={0}'.format(arguments['--cxx'])"
 #   define: "'-DEXTRA_CXXFLAGS=\"{0}\"'.format(arguments['--extra-cxx-flags'])"
 
-enable_language(CXX)
-
-if(NOT DEFINED CMAKE_C_COMPILER_ID)
-    message(FATAL_ERROR "CMAKE_C_COMPILER_ID variable is not defined!")
+if(NOT DEFINED CMAKE_CXX_COMPILER_ID)
+    message(FATAL_ERROR "CMAKE_CXX_COMPILER_ID variable is not defined!")
 endif()
 
-if(NOT CMAKE_C_COMPILER_WORKS)
-    message(FATAL_ERROR "CMAKE_C_COMPILER_WORKS is false!")
+if(NOT CMAKE_CXX_COMPILER_WORKS)
+    message(FATAL_ERROR "CMAKE_CXX_COMPILER_WORKS is false!")
 endif()
 
 if(DEFINED EXTRA_CXXFLAGS)

--- a/modules/fc.cmake
+++ b/modules/fc.cmake
@@ -29,8 +29,6 @@
 #   export: "'FC={0}'.format(arguments['--fc'])"
 #   define: "'-DEXTRA_FCFLAGS=\"{0}\"'.format(arguments['--extra-fc-flags'])"
 
-enable_language(Fortran)
-
 set(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules)
 include_directories(${PROJECT_BINARY_DIR}/modules)
 

--- a/test/boost_header_only/cmake/autocmake.yml
+++ b/test/boost_header_only/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/boost_libs/cmake/autocmake.yml
+++ b/test/boost_libs/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/cxx/cmake/autocmake.yml
+++ b/test/cxx/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/cxx_accelerate/cmake/autocmake.yml
+++ b/test/cxx_accelerate/cmake/autocmake.yml
@@ -1,6 +1,8 @@
 name: example
 min_cmake_version: 2.8
-language: CXX
+language:
+- CXX
+- C
 default_build_type: debug
 modules:
 - cxx:

--- a/test/cxx_accelerate/cmake/autocmake.yml
+++ b/test/cxx_accelerate/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/cxx_cblas/cmake/autocmake.yml
+++ b/test/cxx_cblas/cmake/autocmake.yml
@@ -1,5 +1,8 @@
 name: example
 min_cmake_version: 2.8
+language:
+  - C
+  - CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/extra_cmake_options/cmake/autocmake.yml
+++ b/test/extra_cmake_options/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/fc/cmake/autocmake.yml
+++ b/test/fc/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: Fortran
 default_build_type: debug
 modules:
 - fc:

--- a/test/fc_blas/cmake/autocmake.yml
+++ b/test/fc_blas/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: Fortran
 default_build_type: debug
 modules:
 - fc:

--- a/test/fc_git_info/cmake/autocmake.yml
+++ b/test/fc_git_info/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: Fortran
 default_build_type: debug
 modules:
 - fc:

--- a/test/fc_int64/cmake/autocmake.yml
+++ b/test/fc_int64/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: Fortran
 default_build_type: debug
 modules:
 - fc:

--- a/test/fc_lapack/cmake/autocmake.yml
+++ b/test/fc_lapack/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: Fortran
 default_build_type: debug
 modules:
 - fc:

--- a/test/fc_omp/cmake/autocmake.yml
+++ b/test/fc_omp/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: Fortran
 default_build_type: debug
 modules:
 - fc:

--- a/test/python_interpreter/cmake/autocmake.yml
+++ b/test/python_interpreter/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/python_interpreter_custom/cmake/autocmake.yml
+++ b/test/python_interpreter_custom/cmake/autocmake.yml
@@ -1,5 +1,7 @@
 name: example
 min_cmake_version: 2.8
+language:
+  - CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/python_libs/cmake/autocmake.yml
+++ b/test/python_libs/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/test/python_libs_custom/cmake/autocmake.yml
+++ b/test/python_libs_custom/cmake/autocmake.yml
@@ -1,5 +1,6 @@
 name: example
 min_cmake_version: 2.8
+language: CXX
 default_build_type: debug
 modules:
 - cxx:

--- a/update.py
+++ b/update.py
@@ -141,6 +141,12 @@ def process_yaml(argv):
         sys.stderr.write("ERROR: project name contains a space\n")
         sys.exit(-1)
 
+    if 'language' in config:
+        project_language = ' '.join(config['language']) if isinstance(config['language'], list) else config['language']
+    else:
+        sys.stderr.write("ERROR: you have to specify the project language(s) in autocmake.yml\n")
+        sys.exit(-1)
+
     if 'min_cmake_version' in config:
         min_cmake_version = config['min_cmake_version']
     else:
@@ -179,7 +185,7 @@ def process_yaml(argv):
 
     # create CMakeLists.txt
     print('- generating CMakeLists.txt')
-    s = gen_cmakelists(project_name, min_cmake_version, default_build_type, relative_path, modules)
+    s = gen_cmakelists(project_name, project_language, min_cmake_version, default_build_type, relative_path, modules)
     with open(os.path.join(project_root, 'CMakeLists.txt'), 'w') as f:
         f.write('{0}\n'.format('\n'.join(s)))
 


### PR DESCRIPTION
Parse language field in YAML to generate `project(<PROJECT_NAME <PROJECT_LANGUAGE>)` in `CMakeLists.txt`

**Why?**
Delayed enabling of languages within the `cc.cmake`, `cxx.cmake` and `fc.cmake` causes CMake to load C and C++ as default languages for a project. This is in principle unnecessary for a project that only needs one language. The "only one language" behavior can be enforced by setting the language when declaring the project.

**Questions**
- [x] [This line](https://github.com/robertodr/autocmake/blob/76380d9faacf2af635b902152eee48aba3fa9241/update.py#L145) uses a ternary if to check whether a list of languages or a single language was given. It might not be exactly the most readable piece of code.
- [x] The `enable_language` in [`cc.cmake`](https://github.com/coderefinery/autocmake/blob/master/modules/cc.cmake#L28), [`cxx.cmake`](https://github.com/coderefinery/autocmake/blob/master/modules/cxx.cmake#L28) and [`fc.cmake`](https://github.com/coderefinery/autocmake/blob/master/modules/fc.cmake#L32) is probably redundant.

- [x] **Ready to go**