### PR TITLE
Add -Wall to compiler flags

### DIFF
--- a/compilers/Clang.C.cmake
+++ b/compilers/Clang.C.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED ENV{CFLAGS})
     if(CMAKE_C_COMPILER_ID MATCHES Clang)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
         set(CMAKE_C_FLAGS_RELEASE "-O3")
         set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
     endif()

--- a/compilers/Clang.CXX.cmake
+++ b/compilers/Clang.CXX.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED ENV{CXXFLAGS})
     if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
         set(CMAKE_CXX_FLAGS_RELEASE "-Ofast")
         set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
     endif()

--- a/compilers/GNU.C.cmake
+++ b/compilers/GNU.C.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED ENV{CFLAGS})
     if(CMAKE_C_COMPILER_ID MATCHES GNU)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
         set(CMAKE_C_FLAGS_RELEASE "-O3")
         set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
     endif()

--- a/compilers/GNU.CXX.cmake
+++ b/compilers/GNU.CXX.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED ENV{CXXFLAGS})
     if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
         set(CMAKE_CXX_FLAGS_RELEASE "-O3")
         set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
     endif()

--- a/compilers/GNU.Fortran.cmake
+++ b/compilers/GNU.Fortran.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED ENV{FCFLAGS})
     if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
-        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
+        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wall -Wextra")
         set(CMAKE_Fortran_FLAGS_RELEASE "-O3 -funroll-all-loops")
         set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -fbacktrace")
     endif()

--- a/compilers/Intel.C.cmake
+++ b/compilers/Intel.C.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED ENV{CFLAGS})
     if(CMAKE_C_COMPILER_ID MATCHES Intel)
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
         set(CMAKE_C_FLAGS_RELEASE "-O3")
         set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
     endif()

--- a/compilers/Intel.CXX.cmake
+++ b/compilers/Intel.CXX.cmake
@@ -1,6 +1,6 @@
 if(NOT DEFINED ENV{CXXFLAGS})
     if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
         set(CMAKE_CXX_FLAGS_RELEASE "-O3")
         set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
     endif()


### PR DESCRIPTION
Also add -Wextra, where available. The warning flags are added to `CMAKE_<LANG>_FLAGS` so that one gets warnings also in release builds. 'Cause life is too short to deactivate or ignore compiler warnings!