### PR TITLE
Write cmake_output under build_path

### DIFF
--- a/autocmake/configure.py
+++ b/autocmake/configure.py
@@ -75,7 +75,7 @@ def run_cmake(command, build_path, default_build_path):
         sys.stderr.write(stderr)
 
     # write cmake output to file
-    with open(os.path.join(build_path + 'cmake_output'), 'w') as f:
+    with open(os.path.join(build_path, 'cmake_output'), 'w') as f:
         f.write(stdout)
 
     # change directory and return

--- a/autocmake/configure.py
+++ b/autocmake/configure.py
@@ -18,10 +18,11 @@ def check_cmake_exists(cmake_command):
     """
     from subprocess import Popen, PIPE
 
-    p = Popen('{0} --version'.format(cmake_command),
-              shell=True,
-              stdin=PIPE,
-              stdout=PIPE)
+    p = Popen(
+        '{0} --version'.format(cmake_command),
+        shell=True,
+        stdin=PIPE,
+        stdout=PIPE)
     if not ('cmake version' in p.communicate()[0].decode('UTF-8')):
         sys.stderr.write('   This code is built using CMake\n\n')
         sys.stderr.write('   CMake is not found\n')
@@ -41,8 +42,11 @@ def setup_build_path(build_path):
         fname = os.path.join(build_path, 'CMakeCache.txt')
         if os.path.exists(fname):
             sys.stderr.write('aborting setup\n')
-            sys.stderr.write('build directory {0} which contains CMakeCache.txt already exists\n'.format(build_path))
-            sys.stderr.write('remove the build directory and then rerun setup\n')
+            sys.stderr.write(
+                'build directory {0} which contains CMakeCache.txt already exists\n'.
+                format(build_path))
+            sys.stderr.write(
+                'remove the build directory and then rerun setup\n')
             sys.exit(1)
     else:
         os.makedirs(build_path, 0o755)
@@ -56,11 +60,7 @@ def run_cmake(command, build_path, default_build_path):
     from shutil import rmtree
 
     topdir = os.getcwd()
-    p = Popen(command,
-              shell=True,
-              stdin=PIPE,
-              stdout=PIPE,
-              stderr=PIPE)
+    p = Popen(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     stdout_coded, stderr_coded = p.communicate()
     stdout = stdout_coded.decode('UTF-8')
     stderr = stderr_coded.decode('UTF-8')
@@ -75,7 +75,7 @@ def run_cmake(command, build_path, default_build_path):
         sys.stderr.write(stderr)
 
     # write cmake output to file
-    with open('cmake_output', 'w') as f:
+    with open(os.path.join(build_path + 'cmake_output'), 'w') as f:
         f.write(stdout)
 
     # change directory and return


### PR DESCRIPTION
`cmake_output` was written to the root directory instead of under `build_path`.